### PR TITLE
Fix video_url internal error with exception handling

### DIFF
--- a/service/video.py
+++ b/service/video.py
@@ -42,7 +42,7 @@ def get_description(video_id, youtube):
     return {"description": description}
 
 
-def get_keywords(video_id):
+def get_keywords(video_id, youtube):
 
     search_response = youtube.videos().list(
         part="statistics, snippet",


### PR DESCRIPTION
# Fix video_url internal error with exception handling

## Description

- Added a VideoException class and a method to handle the exceptions caused by invalid url.
- This throws a 400 error and provides a description of the error
- works on endpoints details, descriptions, keywords, transcripts, comment (just implemented in case)
- fixed an error with keywords having the wrong number of params (whoops)

<img width="1079" alt="Screen Shot 2020-08-07 at 12 00 35" src="https://user-images.githubusercontent.com/25355674/89664757-a228ae80-d8a5-11ea-91bc-a0cf6f23e9bc.png">


Fixes #21 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? (Optional)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
